### PR TITLE
Add Python library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,27 @@ jobs:
       - uses: actions/checkout@v3
 
       - run: bin/cargo test --all-features --all-targets --locked
+
+  python:
+    name: Test (Python)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+
+      - name: Test
+        run: |
+          pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.hermit
 
 /target
+__pycache__
+*.pyc

--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ exit(Code::Forbidden);
 exit(Code::Unavailable);
 ```
 
+#### Python
+
+```python
+from exit import Code
+
+Code.Forbidden.exit()  # the user isn't permitted to perform this action
+Code.Unavailable.exit()  # an API this program consumes isn't available
+```
+
 See [the complete list of exit codes](#the-codes).
 
 ### About
@@ -27,6 +36,11 @@ Conventionally, exiting a program with zero indicates success while nonzero indi
 ```golang
 os.Exit(0) // success
 os.Exit(1) // failure
+```
+
+```python
+sys.exit(0) // success
+sys.exit(1) // failure
 ```
 
 But the system call `exit` accepts values between 0 and 255, leaving 254 different ways of expressing failure.

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ os.Exit(1) // failure
 ```
 
 ```python
-sys.exit(0) // success
-sys.exit(1) // failure
+sys.exit(0) # success
+sys.exit(1) # failure
 ```
 
 But the system call `exit` accepts values between 0 and 255, leaving 254 different ways of expressing failure.

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ exit(Code::Unavailable);
 #### Python
 
 ```python
-from exit import Code
+import exit
 
-Code.Forbidden.exit()  # the user isn't permitted to perform this action
-Code.Unavailable.exit()  # an API this program consumes isn't available
+exit.Code.Forbidden.exit()
+exit.Code.Unavailable.exit()
 ```
 
 See [the complete list of exit codes](#the-codes).
@@ -36,11 +36,6 @@ Conventionally, exiting a program with zero indicates success while nonzero indi
 ```golang
 os.Exit(0) // success
 os.Exit(1) // failure
-```
-
-```python
-sys.exit(0) # success
-sys.exit(1) # failure
 ```
 
 But the system call `exit` accepts values between 0 and 255, leaving 254 different ways of expressing failure.

--- a/exit.go
+++ b/exit.go
@@ -24,7 +24,7 @@ const (
 // Exit Codes 80-99 are reserved for user errors.
 const (
 	// UsageError indicates that the program exited unsuccessfully
-	// because it was was used incorrectly.
+	// because it was used incorrectly.
 	//
 	// Examples: a required argument was omitted or an invalid value
 	// was supplied for a flag.

--- a/exit.py
+++ b/exit.py
@@ -6,8 +6,9 @@ This package defines exit codes in two ranges. Exit Codes 80-99 indicate a user 
 of some sort. Exit Codes 100-119 indicate software or system error of some sort.
 """
 
-from enum import Enum
 import sys
+from enum import Enum
+
 
 # Code is the exit code that is passed to the system call `exit` when the
 # program terminates. Conventionally, the value zero indicates success and all

--- a/exit.py
+++ b/exit.py
@@ -1,0 +1,118 @@
+"""
+Defines semantic exit codes which may be used by Command Line tools to aid in
+debugging and instrumentation.
+
+This package defines exit codes in two ranges. Exit Codes 80-99 indicate a user error
+of some sort. Exit Codes 100-119 indicate software or system error of some sort.
+"""
+
+from enum import Enum
+import sys
+
+# Code is the exit code that is passed to the system call `exit` when the
+# program terminates. Conventionally, the value zero indicates success and all
+# other values (1-255) indicate failure.
+class Code(Enum):
+    # there doesn't really appear to be any convention about letter casing
+    # here, so I'm adopting the Go format
+
+    # Indicates that the program exited successfully.
+    OK = 0
+
+    # Indicates that the program exited unsuccessfully but gives no extra
+    # context as to what the failure was.
+    NotOK = 1
+
+    # Exit Codes 80-99 are reserved for user errors.
+
+    # Indicates that the program exited unsuccessfully because it was used
+    # incorrectly.
+    #
+    # Examples: a required argument was omitted or an invalid value was
+    # supplied for a flag.
+    UsageError = 80
+
+    # Indicates that the program exited unsuccessfully because an unrecognized
+    # subcommand was invoked.
+    #
+    # This is intended for CLI multi-tools. When you run a command that doesn't
+    # exist from the shell, the shell exits 127. This is distinct from that
+    # value in that the command itself exists but the subcommand does not (e.g.
+    # `git nope` could exit 81).
+    UnknownSubcommand = 81
+
+    # Indicates that the program exited unsuccessfully because a precondition
+    # wasn't satisfied.
+    #
+    # Examples: the user must be on a VPN before using the program or have
+    # a minimum version of some other software installed.
+    RequirementNotMet = 82
+
+    # Indicates that the program exited unsuccessfully because the user isn't
+    # authorized to perform the requested action.
+    Forbidden = 83
+
+    # Indicates that the program exited unsuccessfully because it has been
+    # migrated to a new location.
+    MovedPermanently = 84
+
+    # Exit Codes 100-119 are reserved for software or system errors.
+
+    # Indicates that the program exited unsuccessfully because of a problem in
+    # its own code.
+    #
+    # Used instead of 1 when the problem is known to be with the program's
+    # code or dependencies.
+    InternalError = 100
+
+    # Indicates that the program exited unsuccessfully because a service it
+    # depends on was not available.
+    #
+    # Examples: A local daemon or remote service did not respond, a connection
+    # was closed unexpectedly, an HTTP service responded with 503.
+    Unavailable = 101
+
+    def is_ok(self):
+        """Reports whether an exit code is okay.
+
+        Returns True if the code is 0.
+        """
+
+        return self.value == 0
+
+    def is_error(self):
+        """Reports whether an exit code is an error.
+
+        Returns True if the code is *not* 0.
+        """
+
+        return self.value != 0
+
+    def is_user_error(self):
+        """Reports whether an exit code is a user error.
+
+        Returns True if the code is in the range 80-99 and False otherwise.
+        """
+
+        return 80 <= self.value <= 99
+
+    def is_software_error(self):
+        """Reports whether an exit code is a software error.
+
+        Returns True if the code is in the range 100-119 and False otherwise.
+        """
+
+        return 100 <= self.value <= 119
+
+    def is_signal(self):
+        """Reports whether an exit code is derived from a signal.
+
+        Returns True if the code is in the range 128-255 and False if not.
+        """
+
+        return 128 < self.value < 255
+
+    def exit(self):
+        """Invoke sys.exit() with this as an exit code."""
+
+        sys.exit(self.value)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,129 @@
+[[package]]
+name = "attrs"
+version = "22.2.0"
+description = "Classes Without Boilerplate"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+cov = ["attrs", "coverage-enable-subprocess", "coverage[toml] (>=5.3)"]
+dev = ["attrs"]
+docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope.interface"]
+tests = ["attrs", "zope.interface"]
+tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=0.971,<0.990)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist"]
+tests_no_zope = ["cloudpickle", "hypothesis", "mypy (>=0.971,<0.990)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist"]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+description = "Cross-platform colored terminal text."
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+
+[[package]]
+name = "exceptiongroup"
+version = "1.1.0"
+description = "Backport of PEP 654 (exception groups)"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+test = ["pytest (>=6)"]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "packaging"
+version = "23.0"
+description = "Core utilities for Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "pytest"
+version = "7.2.0"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+
+[[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.8"
+content-hash = "98df7e4807e49dcbf05ec87f9113cb83fc03eb50d58e61771cb91032023986d5"
+
+[metadata.files]
+attrs = [
+    {file = "attrs-22.2.0-py3-none-any.whl", hash = "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836"},
+    {file = "attrs-22.2.0.tar.gz", hash = "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"},
+]
+colorama = [
+    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+]
+exceptiongroup = [
+    {file = "exceptiongroup-1.1.0-py3-none-any.whl", hash = "sha256:327cbda3da756e2de031a3107b81ab7b3770a602c4d16ca618298c526f4bec1e"},
+    {file = "exceptiongroup-1.1.0.tar.gz", hash = "sha256:bcb67d800a4497e1b404c2dd44fca47d3b7a5e5433dbab67f96c1a685cdfdf23"},
+]
+iniconfig = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
+packaging = [
+    {file = "packaging-23.0-py3-none-any.whl", hash = "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2"},
+    {file = "packaging-23.0.tar.gz", hash = "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"},
+]
+pluggy = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+pytest = [
+    {file = "pytest-7.2.0-py3-none-any.whl", hash = "sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71"},
+    {file = "pytest-7.2.0.tar.gz", hash = "sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59"},
+]
+tomli = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]

--- a/poetry.lock
+++ b/poetry.lock
@@ -15,6 +15,39 @@ tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=0.971,<0.990)", "pympler"
 tests_no_zope = ["cloudpickle", "hypothesis", "mypy (>=0.971,<0.990)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist"]
 
 [[package]]
+name = "black"
+version = "22.12.0"
+description = "The uncompromising code formatter."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
+typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "click"
+version = "8.1.3"
+description = "Composable command line interface toolkit"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -34,6 +67,19 @@ python-versions = ">=3.7"
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "flake8"
+version = "6.0.0"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
+optional = false
+python-versions = ">=3.8.1"
+
+[package.dependencies]
+mccabe = ">=0.7.0,<0.8.0"
+pycodestyle = ">=2.10.0,<2.11.0"
+pyflakes = ">=3.0.0,<3.1.0"
+
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -42,12 +88,62 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "isort"
+version = "5.11.4"
+description = "A Python utility / library to sort Python imports."
+category = "dev"
+optional = false
+python-versions = ">=3.7.0"
+
+[package.extras]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
+pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
+plugins = ["setuptools"]
+requirements-deprecated-finder = ["pip-api", "pipreqs"]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "packaging"
 version = "23.0"
 description = "Core utilities for Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
+
+[[package]]
+name = "pathspec"
+version = "0.10.3"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "platformdirs"
+version = "2.6.2"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
 name = "pluggy"
@@ -60,6 +156,22 @@ python-versions = ">=3.6"
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "pycodestyle"
+version = "2.10.0"
+description = "Python style guide checker"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "pyflakes"
+version = "3.0.1"
+description = "passive checker of Python programs"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "pytest"
@@ -89,15 +201,41 @@ category = "dev"
 optional = false
 python-versions = ">=3.7"
 
+[[package]]
+name = "typing-extensions"
+version = "4.4.0"
+description = "Backported and Experimental Type Hints for Python 3.7+"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.8"
-content-hash = "98df7e4807e49dcbf05ec87f9113cb83fc03eb50d58e61771cb91032023986d5"
+python-versions = "^3.8.1"
+content-hash = "42c7ee19f3f74eafe9f17eb06263d87fe249f00fd1d9d187f8b9505f08406571"
 
 [metadata.files]
 attrs = [
     {file = "attrs-22.2.0-py3-none-any.whl", hash = "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836"},
     {file = "attrs-22.2.0.tar.gz", hash = "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"},
+]
+black = [
+    {file = "black-22.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d"},
+    {file = "black-22.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:159a46a4947f73387b4d83e87ea006dbb2337eab6c879620a3ba52699b1f4351"},
+    {file = "black-22.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f"},
+    {file = "black-22.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4"},
+    {file = "black-22.12.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c116eed0efb9ff870ded8b62fe9f28dd61ef6e9ddd28d83d7d264a38417dcee2"},
+    {file = "black-22.12.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1f58cbe16dfe8c12b7434e50ff889fa479072096d79f0a7f25e4ab8e94cd8350"},
+    {file = "black-22.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77d86c9f3db9b1bf6761244bc0b3572a546f5fe37917a044e02f3166d5aafa7d"},
+    {file = "black-22.12.0-cp38-cp38-win_amd64.whl", hash = "sha256:82d9fe8fee3401e02e79767016b4907820a7dc28d70d137eb397b92ef3cc5bfc"},
+    {file = "black-22.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:101c69b23df9b44247bd88e1d7e90154336ac4992502d4197bdac35dd7ee3320"},
+    {file = "black-22.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:559c7a1ba9a006226f09e4916060982fd27334ae1998e7a38b3f33a37f7a2148"},
+    {file = "black-22.12.0-py3-none-any.whl", hash = "sha256:436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf"},
+    {file = "black-22.12.0.tar.gz", hash = "sha256:229351e5a18ca30f447bf724d007f890f97e13af070bb6ad4c0a441cd7596a2f"},
+]
+click = [
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
 ]
 colorama = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
@@ -107,17 +245,46 @@ exceptiongroup = [
     {file = "exceptiongroup-1.1.0-py3-none-any.whl", hash = "sha256:327cbda3da756e2de031a3107b81ab7b3770a602c4d16ca618298c526f4bec1e"},
     {file = "exceptiongroup-1.1.0.tar.gz", hash = "sha256:bcb67d800a4497e1b404c2dd44fca47d3b7a5e5433dbab67f96c1a685cdfdf23"},
 ]
+flake8 = [
+    {file = "flake8-6.0.0-py2.py3-none-any.whl", hash = "sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7"},
+    {file = "flake8-6.0.0.tar.gz", hash = "sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181"},
+]
 iniconfig = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
+isort = [
+    {file = "isort-5.11.4-py3-none-any.whl", hash = "sha256:c033fd0edb91000a7f09527fe5c75321878f98322a77ddcc81adbd83724afb7b"},
+    {file = "isort-5.11.4.tar.gz", hash = "sha256:6db30c5ded9815d813932c04c2f85a360bcdd35fed496f4d8f35495ef0a261b6"},
+]
+mccabe = []
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 packaging = [
     {file = "packaging-23.0-py3-none-any.whl", hash = "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2"},
     {file = "packaging-23.0.tar.gz", hash = "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"},
 ]
+pathspec = [
+    {file = "pathspec-0.10.3-py3-none-any.whl", hash = "sha256:3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6"},
+    {file = "pathspec-0.10.3.tar.gz", hash = "sha256:56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6"},
+]
+platformdirs = [
+    {file = "platformdirs-2.6.2-py3-none-any.whl", hash = "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490"},
+    {file = "platformdirs-2.6.2.tar.gz", hash = "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"},
+]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.10.0-py2.py3-none-any.whl", hash = "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610"},
+    {file = "pycodestyle-2.10.0.tar.gz", hash = "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053"},
+]
+pyflakes = [
+    {file = "pyflakes-3.0.1-py2.py3-none-any.whl", hash = "sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf"},
+    {file = "pyflakes-3.0.1.tar.gz", hash = "sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd"},
 ]
 pytest = [
     {file = "pytest-7.2.0-py3-none-any.whl", hash = "sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71"},
@@ -127,3 +294,4 @@ tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
+typing-extensions = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "exit"
+version = "0.1.0"
+description = "Semantic exit codes for CLI tools."
+authors = ["John Weachock <jweachock@squareup.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+
+[tool.poetry.dev-dependencies]
+pytest = "^7.2.0"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,13 @@ description = "Semantic exit codes for CLI tools."
 authors = ["John Weachock <jweachock@squareup.com>"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.8.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.0"
+isort = "^5.11.4"
+flake8 = "^6.0.0"
+black = "^22.12.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203,W503,F821
+exclude = docs

--- a/test_readme.py
+++ b/test_readme.py
@@ -1,6 +1,8 @@
-import pytest
-import exit
 import re
+
+import pytest
+
+import exit
 
 with open("README.md") as fp:
     pattern = re.compile("\\| (\\d+) \\| `(\\w+)` \\| .* \\|")
@@ -11,13 +13,21 @@ with open("README.md") as fp:
 
 actual_constants = {code.name: code.value for code in exit.Code}
 
-@pytest.mark.parametrize("code_name", list(set(expected_constants) | set(actual_constants)))
+
+@pytest.mark.parametrize("code_name", set(expected_constants) | set(actual_constants))
 def test_foo(code_name):
     if code_name not in actual_constants:
-        assert False, f"exit.py does not define the exit code {code_name} ({expected_constants[code_name]})"
+        assert (
+            False
+        ), f"exit.py does not define the exit code {code_name} ({expected_constants[code_name]})"
 
     if code_name not in expected_constants:
-        assert False, f"exit.py defines an undocumented exit code {code_name} ({actual_constants[code_name]})"
+        assert (
+            False
+        ), f"exit.py defines an undocumented exit code {code_name} ({actual_constants[code_name]})"
 
     if actual_constants[code_name] != expected_constants[code_name]:
-        assert False, f"exit.py defines {code_name} as {actual_constants[code_name]}, README.md defines it as {expected_constants[code_name]}"
+        assert False, (
+            f"exit.py defines {code_name} as {actual_constants[code_name]},"
+            f"README.md defines it as {expected_constants[code_name]}"
+        )

--- a/test_readme.py
+++ b/test_readme.py
@@ -1,0 +1,23 @@
+import pytest
+import exit
+import re
+
+with open("README.md") as fp:
+    pattern = re.compile("\\| (\\d+) \\| `(\\w+)` \\| .* \\|")
+    expected_constants = {}
+    for line in fp:
+        if result := pattern.match(line):
+            expected_constants[result.group(2)] = int(result.group(1))
+
+actual_constants = {code.name: code.value for code in exit.Code}
+
+@pytest.mark.parametrize("code_name", list(set(expected_constants) | set(actual_constants)))
+def test_foo(code_name):
+    if code_name not in actual_constants:
+        assert False, f"exit.py does not define the exit code {code_name} ({expected_constants[code_name]})"
+
+    if code_name not in expected_constants:
+        assert False, f"exit.py defines an undocumented exit code {code_name} ({actual_constants[code_name]})"
+
+    if actual_constants[code_name] != expected_constants[code_name]:
+        assert False, f"exit.py defines {code_name} as {actual_constants[code_name]}, README.md defines it as {expected_constants[code_name]}"


### PR DESCRIPTION
I'd still like to get some proper packaging in, but just wanted to get eyes on this early and possibly merge without packaging.

This adds a pretty literal port from Go to Python, similar to square/exit#1. I did add several extra helpers to the enum:

* `.is_ok()` -> basically just returns if the exit code is `OK` or not. I feel like this would make some conditionals more readable in consuming programs; eg: `if code.is_ok():` vs `if code.value == 0:`
* `.is_error()` -> opposite of `.is_ok`
* `.exit()` -> invoke `sys.exit()` with the correct error code

Also, it's worth noting that `exit()` itself is a Python builtin so this library name would conflict with that. I'm not actually sure anyone ever uses it outside of a REPL, and it's not officially documented, but it _is_ there: https://docs.python.org/3/library/functions.html#built-in-funcs