### PR TITLE
fix(go): Do not prefix exit code onto error messages

### DIFF
--- a/exit.go
+++ b/exit.go
@@ -134,7 +134,7 @@ type Error struct {
 
 func (e Error) Error() string {
 	if e.Cause != nil {
-		return fmt.Sprintf("exit %d: %s", e.Code, e.Cause)
+		return e.Cause.Error()
 	} else {
 		return fmt.Sprintf("exit %d", e.Code)
 	}


### PR DESCRIPTION
`exit.Wrap` allows you to annotate an exit disposition to an error anywhere in the stack, but `exit 80:` just clutters up the error message in `exit 80: underlying error` — and is maybe even odder when the error is wrapped farther up the stack as in `wrapped: exit 80: underlying error`