### PR TITLE
feat: `FromError` unwraps based on an interface so it works with `*exec.ExitError` as well

### DIFF
--- a/exit.go
+++ b/exit.go
@@ -113,9 +113,10 @@ var (
 )
 
 func FromError(err error) Code {
-	var e Error
+	var e interface{ ExitCode() int }
+
 	if errors.As(err, &e) {
-		return e.Code
+		return e.ExitCode()
 	} else if err == nil {
 		return OK
 	} else {
@@ -142,4 +143,8 @@ func (e Error) Error() string {
 
 func (e Error) Unwrap() error {
 	return e.Cause
+}
+
+func (e Error) ExitCode() int {
+	return int(e.Code)
 }

--- a/exit.go
+++ b/exit.go
@@ -124,6 +124,13 @@ func FromError(err error) Code {
 	}
 }
 
+func WrapIf(err error, code Code) error {
+	if err == nil {
+		return nil
+	}
+	return Wrap(err, code)
+}
+
 func Wrap(err error, code Code) error {
 	return Error{Code: code, Cause: err}
 }

--- a/exit_test.go
+++ b/exit_test.go
@@ -1,0 +1,60 @@
+package exit
+
+import (
+	"fmt"
+	"os/exec"
+	"testing"
+)
+
+func TestFromError(t *testing.T) {
+	// Test cases for the FromError function
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: 0,
+		},
+		{
+			name: "exit error",
+			err:  ErrInternalError,
+			want: 100,
+		},
+		{
+			name: "error",
+			err:  fmt.Errorf("wrapped error"),
+			want: 1,
+		},
+		{
+			name: "wrapped error",
+			err:  Wrap(fmt.Errorf("wrapped error"), UsageError),
+			want: 80,
+		},
+		{
+			name: "error wrapped more than once",
+			err:  Wrap(Wrap(fmt.Errorf("wrapped error"), UsageError), Unavailable),
+			want: 101,
+		},
+		{
+			name: "*exec.ExitError",
+			err:  exec.Command("sh", "-c", "exit 3").Run(),
+			want: 3,
+		},
+		{
+			name: "wrapped *exec.ExitError",
+			err:  Wrap(exec.Command("exit 3").Run(), NotOK),
+			want: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FromError(tt.err); got != tt.want {
+				t.Errorf("FromError(%+v): got %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
And can fall through to Kong based on https://github.com/alecthomas/kong/pull/507